### PR TITLE
Add config-driven tab launcher

### DIFF
--- a/config/tabs.conf
+++ b/config/tabs.conf
@@ -1,0 +1,8 @@
+# Gemini tab
+Gemini|gemini|Ubuntu
+
+# Opencode tab
+Opencode|opencode|Ubuntu
+
+# Codex tab
+Codex|codex|Ubuntu


### PR DESCRIPTION
- **Add default tab configuration template**
- **Load tabs from configuration file**
## Summary
  - load tab definitions from a config file (`~/.config/aisuite/tabs.conf`) with a checked-in template
  - keep the launcher’s current-directory default while reading dynamic tab definitions
  - tighten installer messaging and ensure wt.exe path exports are clearly communicated

 ## Testing
  - `bash scripts/install.sh`
  - copied `config/tabs.conf` into `~/.config/aisuite/tabs.conf`
  - ran `ais` to confirm dynamic tabs open per config entries
